### PR TITLE
fix(Card.ts): desktop 화면 커리어페이지서, 더 큰 너비 요구

### DIFF
--- a/src/components/molecules/Card.ts
+++ b/src/components/molecules/Card.ts
@@ -18,7 +18,7 @@ export const Card: ParentComponent<Props> = styled.div`
     display: flex;
     flex-direction: column;
     width: ${({ width }) => (typeof width === 'number' ? `${width}vw` : width)};
-    max-width: 1080px;
+    max-width: 1280px;
     height: ${({ height }) => (typeof height === 'number' ? `${height}vh` : height)};
     height: ${({ fitContent }) => (fitContent ? 'fit-content' : 'auto')};
     ${({ padding }) => `padding: ${padding};`}


### PR DESCRIPTION
Desktop 화면 Hotfix

<img width="2896" height="1354" alt="image" src="https://github.com/user-attachments/assets/0f3aa40a-2c9b-4ff2-ad7a-17092836f667" />
